### PR TITLE
Remove includes to cdefs.h, internal glibc header

### DIFF
--- a/src/compat/include/sys/queue.h
+++ b/src/compat/include/sys/queue.h
@@ -33,8 +33,6 @@
 #ifndef _SYS_QUEUE_H_
 #define	_SYS_QUEUE_H_
 
-#include <sys/cdefs.h>
-
 /*
  * This file defines four types of data structures: singly-linked lists,
  * singly-linked tail queues, lists and tail queues.

--- a/src/compat/subr_sbuf.c
+++ b/src/compat/subr_sbuf.c
@@ -26,7 +26,6 @@
  * SUCH DAMAGE.
  */
 
-#include <sys/cdefs.h>
 /*
 __FBSDID("$FreeBSD: release/10.0.0/sys/kern/subr_sbuf.c 255805 2013-09-22 23:47:56Z des $");
 */


### PR DESCRIPTION
https://wiki.musl-libc.org/faq.html#Q:-When-compiling-something-against-musl,-I-get-error-messages-about-%3Ccode%3Esys/cdefs.h%3C/code%3E